### PR TITLE
fix: fix for Unity Issue UUM-86782

### DIFF
--- a/Runtime/Abstract/IUpdateJob.cs
+++ b/Runtime/Abstract/IUpdateJob.cs
@@ -9,6 +9,7 @@ namespace JobIt.Runtime.Abstract
     /// </summary>
     public interface IUpdateJob : IDisposable
     {
+        internal void PreStartJob();
         public JobHandle StartJob(JobHandle dependsOn = default);
         public void EndJob();
         public GameObject GetGameObject();

--- a/Runtime/Abstract/InvokedUpdateJob.cs
+++ b/Runtime/Abstract/InvokedUpdateJob.cs
@@ -14,7 +14,6 @@ namespace JobIt.Runtime.Abstract
         /// This job is considered running with the Invoker is running
         /// </summary>
         public sealed override bool IsRunning => Invoker.IsRunning;
-        protected override int JobPriority => 0;
 
         public sealed override void Awake()
         {

--- a/Runtime/Abstract/JobScheduleInvoker.cs
+++ b/Runtime/Abstract/JobScheduleInvoker.cs
@@ -154,6 +154,12 @@ namespace JobIt.Runtime.Abstract
             CurrentHandles = new NativeList<JobHandle>(10, Allocator.Temp);
             var currentPriority = JobList[0].ExecutionOrder;
 
+            // Execute the job setup step. 
+            for (var i = 0; i < JobList.Count; i++)
+            {
+                JobList[i].Job.PreStartJob();
+            }
+
             for (var i = 0; i < JobList.Count; i++)
             {
                 var p = JobList[i].ExecutionOrder;

--- a/Tests/MockClasses/MockClasses.cs
+++ b/Tests/MockClasses/MockClasses.cs
@@ -5,7 +5,6 @@ using JobIt.Runtime.Impl.JobScheduler;
 using Unity.Collections;
 using Unity.Jobs;
 using UnityEngine;
-using UnityEngine.Serialization;
 
 namespace JobIt.Tests.MockClasses
 {
@@ -13,8 +12,6 @@ namespace JobIt.Tests.MockClasses
     {
         public NativeList<int> ValueList;
         public JobHandle Handle;
-
-        protected override int JobPriority => 0;
 
         protected override void BuildNativeContainers()
         {


### PR DESCRIPTION
Fix for [UUM-86782](https://issuetracker.unity3d.com/issues/the-editor-freezes-when-schedulereadonly-of-ijobparallelfortransform-with-dependency-is-used) that occurs in several version of Unity 6.

Because the JobScheduleInvoker previously had each job perform its data actions before running, this deadlock could occur if an earlier job was set to ScheduleReadOnly and accessed the same transform a later job was using.

Now all data actions are performed before the jobs are scheduled, thus preventing this deadlock from happening. Given that this entails performing a 'PreStart' step for each job, the new PreStartJob protected function was built. This function can be safely overwritten in an UpdateJob to perform some set of operations before the jobs start being scheduled.